### PR TITLE
sort more things so that the hubscr tests pass

### DIFF
--- a/src/align2html/Segment.pm
+++ b/src/align2html/Segment.pm
@@ -46,7 +46,7 @@ sub SetY
 {
 	my ($self, $ypos) = @_;
 		
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		$self->{TOKENS}{$tknid}->SetYPos($ypos);
 	}
@@ -56,7 +56,7 @@ sub isTokenInSegment
 {
 	my ($self, $tokenid) = @_;
 	
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		return 1 if($tknid == $tokenid);
 	}
@@ -68,7 +68,7 @@ sub CalculateMinMaxX
 {
 	my ($self) = @_;
 	
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		next if( ($self->{TOKENS}{$tknid}->{XSTARTPOS} == 0) && ($self->{TOKENS}{$tknid}->{XENDPOS} == 0) && ($self->{TOKENS}{$tknid}->{TEXT} eq "") );
 		$self->{MINX} = $self->{TOKENS}{$tknid}->{XSTARTPOS} if($self->{MINX} > $self->{TOKENS}{$tknid}->{XSTARTPOS});
@@ -80,7 +80,7 @@ sub HasOnlyOneFakeToken
 {
     my ($self) = @_;
     
-    foreach my $tknid(keys %{ $self->{TOKENS} })
+    foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		return 0 if( !( ($self->{TOKENS}{$tknid}->{XSTARTPOS} == 0) && ($self->{TOKENS}{$tknid}->{XENDPOS} == 0) && ($self->{TOKENS}{$tknid}->{TEXT} eq "") ) );
 	}
@@ -92,7 +92,7 @@ sub CleanSegmentPrevNext
 {
 	my ($self) = @_;
 	
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		my $myToken = $self->{TOKENS}{$tknid};
 		
@@ -196,7 +196,7 @@ sub MultiGraphXY
 			$maxlengh = $tokenPositions{$tken}{XE} if($tokenPositions{$tken}{XE} > $maxlengh);
 		}
 		
-		foreach my $tknid(keys %{ $self->{TOKENS} })
+		foreach my $tknid(sort keys %{ $self->{TOKENS} })
 		{
 			my $updown = 1;
 			my $base = 0;
@@ -242,7 +242,7 @@ sub GetDraw
 	my @listfirsts;
 	my @listlasts;
 	
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{
 		my @prevtkn = @{ $self->{TOKENS}{$tknid}->{PREVTKNID} };
 		my @nexttkn = @{ $self->{TOKENS}{$tknid}->{NEXTTKNID} };
@@ -313,7 +313,7 @@ sub GetDraw
 		$output .= $output2;
 	}
 	
-	foreach my $tknid(keys %{ $self->{TOKENS} })
+	foreach my $tknid(sort keys %{ $self->{TOKENS} })
 	{		
 		$output .= $self->{TOKENS}{$tknid}->GetDraw($minx);
 	}

--- a/src/align2html/SegmentGroup.pm
+++ b/src/align2html/SegmentGroup.pm
@@ -260,7 +260,7 @@ sub GetFillREFHYP
 	my $output = "";
 	my @valuessep1;
 	
-	foreach my $spkrID(keys %{ $self->{SPKRYS} })
+	foreach my $spkrID(sort keys %{ $self->{SPKRYS} })
 	{
 		push(@valuessep1, $self->{SPKRYS}{$spkrID} - 25);
 		push(@valuessep1, $self->{SPKRYS}{$spkrID} + $self->{SPKRHEIGHT}{$spkrID});
@@ -312,7 +312,7 @@ sub GetSeparationLines
 	$output .= sprintf("jg.setColor(\"black\");\n");
 	$output .= sprintf("jg.setFont(\"verdana\",\"12px\",Font.PLAIN);\n");
 	
-	foreach my $spkrID(keys %{ $self->{SPKRYS} })
+	foreach my $spkrID(sort keys %{ $self->{SPKRYS} })
 	{
 		my $spkName = $spkrID;
 		$spkName =~ s/^ref://;
@@ -325,7 +325,7 @@ sub GetSeparationLines
 	
 	my @valuessep1;
 	
-	foreach my $spkrID(keys %{ $self->{SPKRYS} })
+	foreach my $spkrID(sort keys %{ $self->{SPKRYS} })
 	{
 		push(@valuessep1, $self->{SPKRYS}{$spkrID} - 25);
 		push(@valuessep1, $self->{SPKRYS}{$spkrID} + $self->{SPKRHEIGHT}{$spkrID});


### PR DESCRIPTION
I had to add more sorts on the top of d1e4744669e62be18cfaff97622bd0d2a4301ab5
Now the tests pass both on perl 5.18 and 5.26 (both on MacOSX).

Actually, not all of them were necessary to make the test pass (only a subset was), but I edited them anyway, I don't think there is a harm in iterating through hashes via sorted sequence.
But I can provide the minimal patch file that has only the differences that were needed to make this test pass (in case there is a wish for "minimal" patch).