### PR TITLE
Support DESTDIR

### DIFF
--- a/src/acomp/makefile.in
+++ b/src/acomp/makefile.in
@@ -19,7 +19,7 @@ check: all
 	@echo "   No tests defined for acomp.pl"
 
 install: all
-	cp acomp.pl $(bindir)
+	cp acomp.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/align2html/makefile.in
+++ b/src/align2html/makefile.in
@@ -12,8 +12,8 @@ check: all
 	@echo "No Tests for align2html.pl"
 
 install: all
-	perl buildInstallVersion.pl > $(bindir)/align2html.pl
-	chmod +x $(bindir)/align2html.pl
+	perl buildInstallVersion.pl > $(DESTDIR)$(bindir)/align2html.pl
+	chmod +x $(DESTDIR)$(bindir)/align2html.pl
 
 buildPackFile:
 	buildPack.pl > packImageTarFile

--- a/src/asclite/core/makefile.in
+++ b/src/asclite/core/makefile.in
@@ -75,7 +75,7 @@ realclean: distclean
 
 install: all
 	for p in $(PROGRAMS); do \
-		$(INSTALL) $$p $(bindir)/$$p; \
+		$(INSTALL) $$p $(DESTDIR)$(bindir)/$$p; \
 	done
 
 check:

--- a/src/chfilt/makefile.in
+++ b/src/chfilt/makefile.in
@@ -32,7 +32,7 @@ check: all
 	@echo "   chfilt.pl tests successfully completed"
 
 install: all
-	cp chfilt.pl $(bindir)
+	cp chfilt.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/csrfilt/makefile.in
+++ b/src/csrfilt/makefile.in
@@ -20,7 +20,7 @@ check: all
 	@echo "   csrfilt.sh successfully completed"
 
 install: all
-	cp csrfilt.sh $(bindir)
+	cp csrfilt.sh $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/ctmValidator/makefile.in
+++ b/src/ctmValidator/makefile.in
@@ -11,7 +11,7 @@ check: all
 	(cd test_suite; $(SHELL) RunTest.sh ../ctmValidator.pl)
 
 install: all
-	cp ctmValidator.pl $(bindir)
+	cp ctmValidator.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/def_art/makefile.in
+++ b/src/def_art/makefile.in
@@ -19,7 +19,7 @@ check: all
 	@echo "   def_art.pl passed without tests"
 
 install: all
-	cp def_art.pl $(bindir)
+	cp def_art.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/hamzaNorm/makefile.in
+++ b/src/hamzaNorm/makefile.in
@@ -25,7 +25,7 @@ check: all
 	@echo "   hamzaNorm.pl tests successfully completed"
 
 install: all
-	cp hamzaNorm.pl $(bindir)
+	cp hamzaNorm.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/hubscr/makefile.in
+++ b/src/hubscr/makefile.in
@@ -21,7 +21,7 @@ check: all
 	@echo "   hubscr.pl tests successfully completed"
 
 install: all
-	cp hubscr.pl $(bindir)
+	cp hubscr.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/md-eval/makefile.in
+++ b/src/md-eval/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for md-eval.pl"
 
 install: all
-	cp md-eval.pl $(bindir)
+	cp md-eval.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/mergectm2rttm/makefile.in
+++ b/src/mergectm2rttm/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for mergectm2rttm.pl"
 
 install: all
-	cp mergectm2rttm.pl $(bindir)
+	cp mergectm2rttm.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/rfilter1/makefile.in
+++ b/src/rfilter1/makefile.in
@@ -31,7 +31,7 @@ check:
 	@echo "   rfilter1 tests successfully completed"
 
 install: all
-	install rfilter1 $(bindir)
+	install rfilter1 $(DESTDIR)$(bindir)
 
 clean:
 	$(RM) rfilter1

--- a/src/rttm2ctm/makefile.in
+++ b/src/rttm2ctm/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for rttm2ctm.pl"
 
 install: all
-	cp rttm2ctm.pl $(bindir)
+	cp rttm2ctm.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/rttmSmooth/makefile.in
+++ b/src/rttmSmooth/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for rttmSmooth.pl"
 
 install: all
-	cp rttmSmooth.pl $(bindir)
+	cp rttmSmooth.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/rttmSort/makefile.in
+++ b/src/rttmSort/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for rttmSort.pl"
 
 install: all
-	cp rttmSort.pl $(bindir)
+	cp rttmSort.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/rttmValidator/makefile.in
+++ b/src/rttmValidator/makefile.in
@@ -11,7 +11,7 @@ check: all
 	(cd test_suite; $(SHELL) RunTest.sh ../rttmValidator.pl)
 
 install: all
-	cp rttmValidator.pl $(bindir)
+	cp rttmValidator.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/sclite/makefile.in
+++ b/src/sclite/makefile.in
@@ -158,17 +158,17 @@ realclean: distclean
 
 install: all testinstalldirs
 	set -e; for p in $(PROGRAMS); do \
-	  $(INSTALL) $$p $(bindir)/$$p; \
+	  $(INSTALL) $$p $(DESTDIR)$(bindir)/$$p; \
 	done
 #REenable this later
 #	set -e; for p in `(cd ../doc ; ls *.1)`; do \
-#	  $(INSTALL) ../doc/$$p $(man1dir)/$$p; \
+#	  $(INSTALL) ../doc/$$p $(DESTDIR)$(man1dir)/$$p; \
 #	done
 #	@echo "!!!!  If 'man sclite' does not work, run 'catman -M $(mandir)'"
 #	@echo "!!!!  to make manual pages accessible."
 
 testinstalldirs:
-	@-set -e; for p in $(bindir) $(man1dir) $(man5dir); do \
+	@-set -e; for p in $(DESTDIR)$(bindir) $(DESTDIR)$(man1dir) $(DESTDIR)$(man5dir); do \
 	   if test ! -d $$p ; then \
 		echo "Error: directory $$p doesn't exist"; \
 	   fi ; \

--- a/src/slatreport/makefile.in
+++ b/src/slatreport/makefile.in
@@ -24,7 +24,7 @@ check: all
 	@echo "   slatreport.pl tests successfully completed"
 
 install: all
-	cp slatreport.pl $(bindir)
+	cp slatreport.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/spkr2sad/makefile.in
+++ b/src/spkr2sad/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for spkr2sad.pl"
 
 install: all
-	cp spkr2sad.pl $(bindir)
+	cp spkr2sad.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/stm2rttm/makefile.in
+++ b/src/stm2rttm/makefile.in
@@ -15,7 +15,7 @@ check: all
 	@echo "No Tests for stm2rttm.pl"
 
 install: all
-	cp stm2rttm.pl $(bindir)
+	cp stm2rttm.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/stmValidator/makefile.in
+++ b/src/stmValidator/makefile.in
@@ -13,8 +13,8 @@ check: all
 	(cd test_suite; $(SHELL) RunTest.sh ../stmValidator.pl)
 
 install: all
-	perl buildInstallVersion.pl > $(bindir)/stmValidator.pl
-	chmod +x $(bindir)/stmValidator.pl
+	perl buildInstallVersion.pl > $(DESTDIR)$(bindir)/stmValidator.pl
+	chmod +x $(DESTDIR)$(bindir)/stmValidator.pl
 
 STMList.pl:
 

--- a/src/tanweenFilt/makefile.in
+++ b/src/tanweenFilt/makefile.in
@@ -31,7 +31,7 @@ check: all
 	@echo "   tanweenFilt.pl tests successfully completed"
 
 install: all
-	cp tanweenFilt.pl $(bindir)
+	cp tanweenFilt.pl $(DESTDIR)$(bindir)
 
 clean:
 

--- a/src/utf_filt/makefile.in
+++ b/src/utf_filt/makefile.in
@@ -26,8 +26,8 @@ check: all
 	fi	
 
 install: all
-	@sed 's:"nsgmls":"'$(NSGMLS)'":' < utf_filt.pl > $(bindir)/utf_filt.pl
-	@chmod +x $(bindir)/utf_filt.pl
+	@sed 's:"nsgmls":"'$(NSGMLS)'":' < utf_filt.pl > $(DESTDIR)$(bindir)/utf_filt.pl
+	@chmod +x $(DESTDIR)$(bindir)/utf_filt.pl
 
 config.sh: config.in
 	autoconf config.in | sed 's/Makefile/makefile/g' > config.sh


### PR DESCRIPTION
The build system does not support the `DESTDIR` environment variable, which users and package management systems use in order to stage an installation to a temporary directory. This PR provides this missing support. This patch has been in MacPorts [since 2010](https://github.com/macports/macports-ports/commit/c6af28e8c5674a100aa2574603ed0a21cd3eb38c).