### PR TITLE
Change sclecho back to echo

### DIFF
--- a/src/sclite/testdata/tsclite.sh
+++ b/src/sclite/testdata/tsclite.sh
@@ -52,7 +52,7 @@ else
 	SLM_ENABLED=1
 	echo "    SLM-Toolkit Enabled"
 fi
-sclecho ""
+echo ""
 
 if [ -d $OUT ] ; then
 	echo "Shall I delete the output directory \"$OUT\"'s contents [y]"


### PR DESCRIPTION
This reverts an apparent typo introduced in 2f3a852 which caused the message "./tsclite.sh: line 55: sclecho: command not found" to appear when running "make check".