### PR TITLE
Use correct C/C++ compiler and flags as needed

### DIFF
--- a/src/asclite/core/makefile.in
+++ b/src/asclite/core/makefile.in
@@ -5,13 +5,14 @@
 srcdir = @srcdir@
 VPATH = @srcdir@
 
-CC = @CXX@
+CC = @CC@
+CXX = @CXX@
 INSTALL = @INSTALL@
 
+CFLAGS = @CFLAGS@
 CPPFLAGS = @CPPFLAGS@
 CXXFLAGS = @CXXFLAGS@
 DEFS = @DEFS@
-CFLAGS = @CFLAGS@
 LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
 
@@ -54,13 +55,14 @@ PROGRAMS = asclite
 all: makefile $(PROGRAMS)
 
 
-COMPILE = $(CC) -c $(OFLAGS) $(DEFS) -I. $(CFLAGS) $(CPPFLAGS) $(CXXFLAGS)
+.c.o:
+	$(CC) -c $(OFLAGS) $(DEFS) -I. $(CFLAGS) $(CPPFLAGS) -o $@ $<
 
 .cpp.o:
-	$(COMPILE) $<
+	$(CXX) -c $(OFLAGS) $(DEFS) -I. $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
 
 asclite: $(src_o)
-	$(CXX) -o $@ $(CFLAGS) $(LDFLAGS) $(src_o) $(LIBS) 
+	$(CXX) -o $@ $(CXXFLAGS) $(LDFLAGS) $(src_o) $(LIBS)
 
 clean:
 	rm -f *.o lzma/*.o $(PROGRAMS) core.*

--- a/src/asclite/test/makefile.in
+++ b/src/asclite/test/makefile.in
@@ -5,12 +5,12 @@
 srcdir = @srcdir@
 VPATH = @srcdir@
 
-CC = @CXX@
+CXX = @CXX@
 INSTALL = @INSTALL@
 
 CPPFLAGS = @CPPFLAGS@
+CXXFLAGS = @CXXFLAGS@
 DEFS = @DEFS@
-CFLAGS = @CFLAGS@
 LDFLAGS = @LDFLAGS@
 LIBS = @LIBS@
 
@@ -53,13 +53,11 @@ PROGRAMS = asclite_test
 all: makefile $(PROGRAMS)
 
 
-COMPILE = $(CC) -c $(OFLAGS) $(DEFS) -I. -I../core $(CFLAGS) $(CPPFLAGS)
-
 .cpp.o:
-	$(COMPILE) $<
+	$(CXX) -c $(OFLAGS) $(DEFS) -I. -I../core $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
 
 asclite_test: $(src_o)
-	$(CXX) -o $@ $(CFLAGS) $(LDFLAGS) $(src_o) $(LIBS) 
+	$(CXX) -o $@ $(CXXFLAGS) $(LDFLAGS) $(src_o) $(LIBS)
 
 clean:
 	rm -f *.o $(PROGRAMS) core.*

--- a/src/sclite/makefile.in
+++ b/src/sclite/makefile.in
@@ -110,31 +110,29 @@ distribution = tk_dist
 all: makefile $(SLM_TARGETS) $(PROGRAMS)
 
 
-COMPILE = $(CC) -c $(CPPFLAGS) $(DEFS) -I. $(CFLAGS)
-
 .c.o:
-	$(COMPILE) $<
+	$(CC) -c $(OFLAGS) $(DEFS) -I. $(CFLAGS) $(CPPFLAGS) -o $@ $<
 
-sclite: $(lib_o) sclite.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) sclite.c $(LIBS) 
-sc_stats: $(lib_o) sc_stats.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) sc_stats.c $(LIBS) 
-rover: $(lib_o) rover.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) rover.c $(LIBS) 
-mcnemar: $(lib_o) mcnemar.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) mcnemar.c $(LIBS)
-sctkUnit: $(lib_o)sctkUnit.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) sctkUnit.c $(LIBS) 
-sign: $(lib_o) sign.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) sign.c $(LIBS)
-sclite_tolower: $(lib_o) sclite_tolower.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) sclite_tolower.c $(LIBS)
-$(TEST_PROGRAMS): $(lib_o) $$@.c
-	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) $@.c $(LIBS) 
+sclite: $(lib_o) sclite.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+sc_stats: $(lib_o) sc_stats.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+rover: $(lib_o) rover.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+mcnemar: $(lib_o) mcnemar.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+sctkUnit: $(lib_o) sctkUnit.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+sign: $(lib_o) sign.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+sclite_tolower: $(lib_o) sclite_tolower.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
+$(TEST_PROGRAMS): $(lib_o) $$@.o
+	$(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ $(LIBS)
 $(PURIFY_PROGRAMS): $(lib_o)
-	purify $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) `echo $@.c|sed 's/_pure//'` $(LIBS) 
+	purify $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ `echo $@.c|sed 's/_pure//'` $(LIBS)
 $(PURECOV_PROGRAMS): $(lib_o)
-	purecov $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(lib_o) `echo $@.c|sed 's/_purecov//'` $(LIBS) 
+	purecov $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $^ `echo $@.c|sed 's/_purecov//'` $(LIBS)
 
 ### make a rule to compile the SLM toolkit
 slm_v2/lib/SLM2.a:


### PR DESCRIPTION
Previously, in the asclite makefiles, CC was used to refer to the C++ compiler; CFLAGS and CXXFLAGS were both passed to this compiler; C files were being compiled with the C++ compiler, causing the message "clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated" to be printed; and "c++" was used as the linker, ignoring the user's requested C++ compiler and flags.

Now, CC refers to the C compiler; CXX refers to the C++ compiler; CFLAGS are passed to the C compiler; CXXFLAGS are passed to the C++ compiler; C files are compiled with the C compiler; C++ files are compiled with the C++ compiler; and CXX is used for linking.

In addition, the sclite makefile is cleaned up so that the executables are not compiled and linked as a single step; dependencies are obtained from the target declaration rather than being repeated in the link command; CPPFLAGS are specified after local -I flags so that any -I flags that might be in the user's CPPFLAGS do not cause incorrect headers to be found; and OFLAGS are added to the compilation step to match what's done in asclite's makefiles, though this is a nonstandard variable and it is not defined anywhere (presumably it was expected that a user might set it).