### PR TITLE
Update compute_acc_binomial function in statdist.c

### DIFF
--- a/src/sclite/statdist.c
+++ b/src/sclite/statdist.c
@@ -786,7 +786,7 @@ double compute_acc_binomial(int R, int n, double p)
       double mean, stdev, zstat, flip;
       mean = n*p;
       stdev = sqrt(n*p*(1.0-p));
-      flip = (double)R * 0.5;
+      flip = (double)R + 0.5;
       zstat = (flip - mean) / stdev;
       sum = normprob((double)fabs(zstat));
       if (zstat < 0.0)  sum = 1.0 - sum;


### PR DESCRIPTION
Corrected an error in the implementation of the normal approximation of the accumulated binomial distribution. In the previous implementation, the results of the McNemar test were incorrect under the normal approximation. It was impossible to score above the threshold for significance (i.e., to have an insignificant result) unless the unique utterance errors were equal in the two systems. Thus, for example, systems with 10 and 11 u.u.e.s, respectively, would erroneously be found to be significantly different. In contrast, systems with 9 and 11 u.u.e.s, respectively, were correctly found not to be significantly different under the properly implemented exact binomial calculation of McNemar.